### PR TITLE
refactor: zig v0.14.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Because `cron` needs to be used together with `datetime`, you need to add both o
            .hash = "1220f3f1e6659f434657452f4727889a2424c1b78ac88775bd1f036858a1e974ad41",
        },
        .datetime = .{
-           .url = "https://github.com/frmdstryr/zig-datetime/archive/ddecb4e508e99ad6ab1314378225413959d54756.tar.gz",
-           .hash = "12202cbb909feb6b09164ac997307c6b1ab35cb05a846198cf41f7ec608d842c1761",
-       }
+            .url = "git+https://github.com/frmdstryr/zig-datetime?ref=master#4d0e84cd8844c0672e0cbe247a3130750c9e0f27",
+            .hash = "datetime-0.8.0-cJNXzJSJAQB5RKwPglxoEq875GmehZoLjuAlKzvWp4_O",
+        },
     },
 }
 ```

--- a/build.zig
+++ b/build.zig
@@ -30,7 +30,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const opts = .{ .target = target, .optimize = optimize };
-    const datetime_module = b.dependency("datetime", opts).module("zig-datetime");
+    const datetime_module = b.dependency("datetime", opts).module("datetime");
     lib.root_module.addImport("datetime", datetime_module);
     // lib.addModule("datetime", datetime_module);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,10 +1,11 @@
 .{
-    .name = "cron",
+    .name = .cron,
+    .fingerprint = 0x17cd00f8c4ea808e,
     .version = "0.1.0",
     .dependencies = .{
         .datetime = .{
-            .url = "https://github.com/frmdstryr/zig-datetime/archive/70aebf28fb3e137cd84123a9349d157a74708721.tar.gz",
-            .hash = "122077215ce36e125a490e59ec1748ffd4f6ba00d4d14f7308978e5360711d72d77f",
+            .url = "git+https://github.com/frmdstryr/zig-datetime?ref=master#4d0e84cd8844c0672e0cbe247a3130750c9e0f27",
+            .hash = "datetime-0.8.0-cJNXzJSJAQB5RKwPglxoEq875GmehZoLjuAlKzvWp4_O",
         },
     },
     .paths = .{""},

--- a/src/cron.zig
+++ b/src/cron.zig
@@ -69,7 +69,7 @@ pub const Cron = struct {
         const lower_input = std.ascii.lowerString(&buf_, input);
         const cron_expr = self.convertAlias(lower_input);
 
-        var it = std.mem.split(u8, cron_expr, " ");
+        var it = std.mem.splitSequence(u8, cron_expr, " ");
         var total_field: u3 = 0;
         while (it.next()) |_| {
             total_field += 1;
@@ -99,7 +99,7 @@ pub const Cron = struct {
         var i: u4 = 0;
         var fields: [7]CronField = undefined;
 
-        it = std.mem.split(u8, self.buf[0..length], " ");
+        it = std.mem.splitSequence(u8, self.buf[0..length], " ");
         while (it.next()) |entry| {
             const tag = try std.meta.intToEnum(FieldTag, i);
             const field = try CronField.init(tag, entry);
@@ -120,12 +120,12 @@ pub const Cron = struct {
         return;
     }
 
-    /// handle crontab alias
-    /// @yearly (or @annually) 	Run once a year at midnight of 1 January 	0 0 1 1 *
-    /// @monthly 	Run once a month at midnight of the first day of the month 	0 0 1 * *
-    /// @weekly 	Run once a week at midnight on Sunday morning 	0 0 * * 0
-    /// @daily (or @midnight) 	Run once a day at midnight 	0 0 * * *
-    /// @hourly 	Run once an hour at the beginning of the hour 	0 * * * *
+    // handle crontab alias
+    // @yearly (or @annually) Run once a year at midnight of 1 January 0 0 1 1 *
+    // @monthly Run once a month at midnight of the first day of the month 0 0 1 * *
+    // @weekly Run once a week at midnight on Sunday morning 0 0 * * 0
+    // @daily (or @midnight) Run once a day at midnight 0 0 * * *
+    // @hourly Run once an hour at the beginning of the hour 0 * * * *
     fn convertAlias(self: Self, expr: []const u8) []const u8 {
         _ = self;
         if (std.mem.eql(u8, expr, "@yearly")) {

--- a/src/expr.zig
+++ b/src/expr.zig
@@ -111,7 +111,7 @@ pub const CronField = struct {
         var end: u16 = undefined;
         var has_wildcard = false;
 
-        var it = std.mem.split(u8, text, ",");
+        var it = std.mem.splitSequence(u8, text, ",");
         while (it.next()) |e| {
             if (std.mem.eql(u8, e, "*") or std.mem.eql(u8, e, "?")) {
                 has_wildcard = true;
@@ -329,7 +329,7 @@ pub const CronField = struct {
             return true;
         }
 
-        var it = std.mem.split(u8, self.text, ",");
+        var it = std.mem.splitSequence(u8, self.text, ",");
 
         while (it.next()) |x| {
             if (std.mem.eql(u8, x, "l")) {


### PR DESCRIPTION
- Fixed build.zig.zon to get up to date datetime dependency that supports zig 0.14
- Updated README.md to match new dependency version
- Fixed split usage to splitSequence which was deprecated
- Updated build.zig because on new version zig-datetime is changed to datetime only

Hi there one of my project is depending on this library and since zig 0.14.0 is out it's best to keep up to date so that things keep working.

Thanks.