### PR TITLE
refactor: Update datetime dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,22 @@
-**/zig-out/
-**/zig-cache/
-**/testdata/
-kcov-out/
+# This file is for zig-specific build artifacts.
+# If you have OS-specific or editor-specific files to ignore,
+# such as *.swp or .DS_Store, put those in your global
+# ~/.gitignore and put this in your ~/.gitconfig:
+#
+# [core]
+#     excludesfile = ~/.gitignore
+#
+# Cheers!
+# -andrewrk
+
+.zig-cache/
+zig-out/
+/release/
+/debug/
+/build/
+/build-*/
+/docgen_tmp/
+
+# Although this was renamed to .zig-cache, let's leave it here for a few
+# releases to make it less annoying to work with multiple branches.
+zig-cache/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ pub fn main() !void {
 ## Installation For Zig 0.14
 
 Please refer to the latest Zig package documentation.
+```
+zig fetch --save=cron git+https://github.com/dying-will-bullet/cron?ref=master#447a621f3f79f80e4f42ab3ad5d39ccf3f368ec5
+```
+
+```
+zig fetch --save=datetime git+https://github.com/frmdstryr/zig-datetime?ref=master#52d4fbe43a758589b74411ffec8ebcb1f12e2d13
+```
 
 ## Installation For Zig 0.11
 
@@ -85,8 +92,9 @@ Because `cron` needs to be used together with `datetime`, you need to add both o
 
 ```
 .{
-    .name = "my-project",
+    .name = my_project,
     .version = "0.1.0",
+    .fingerprint = xxxxxxxxxxxxxxx,
     .dependencies = .{
        .cron = .{
            .url = "https://github.com/dying-will-bullet/cron/archive/refs/tags/v0.2.0.tar.gz",

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Because `cron` needs to be used together with `datetime`, you need to add both o
            .hash = "1220f3f1e6659f434657452f4727889a2424c1b78ac88775bd1f036858a1e974ad41",
        },
        .datetime = .{
-            .url = "git+https://github.com/frmdstryr/zig-datetime?ref=master#4d0e84cd8844c0672e0cbe247a3130750c9e0f27",
-            .hash = "datetime-0.8.0-cJNXzJSJAQB5RKwPglxoEq875GmehZoLjuAlKzvWp4_O",
+            .url = "git+https://github.com/frmdstryr/zig-datetime?ref=master#52d4fbe43a758589b74411ffec8ebcb1f12e2d13",
+            .hash = "datetime-0.8.0-cJNXzNiMAQBz4RV6Gz7qUNeE-xLDNLs_jNU5_zIZ48as",
         },
     },
 }

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pub fn main() !void {
 
 Please refer to the latest Zig package documentation.
 ```
-zig fetch --save=cron git+https://github.com/dying-will-bullet/cron?ref=master#447a621f3f79f80e4f42ab3ad5d39ccf3f368ec5
+zig fetch --save=cron git+https://github.com/dying-will-bullet/cron#master
 ```
 
 ```

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.3.0",
     .dependencies = .{
         .datetime = .{
-            .url = "git+https://github.com/frmdstryr/zig-datetime?ref=master#4d0e84cd8844c0672e0cbe247a3130750c9e0f27",
-            .hash = "datetime-0.8.0-cJNXzJSJAQB5RKwPglxoEq875GmehZoLjuAlKzvWp4_O",
+            .url = "git+https://github.com/frmdstryr/zig-datetime?ref=master#52d4fbe43a758589b74411ffec8ebcb1f12e2d13",
+            .hash = "datetime-0.8.0-cJNXzNiMAQBz4RV6Gz7qUNeE-xLDNLs_jNU5_zIZ48as",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
- Yesteday one of my PR to datetime repo got merged to master [Here is the PR](https://github.com/frmdstryr/zig-datetime/pull/37)
- The change was enabling us to get timezone with a getter function that accepts timezone name as string
- This is now causing depedency conflict between latest version of datetime and the version being used in this repo
- I changed the build.zig.zon file to use the latest datetime that gives you flexibility to get timezone with a run-time string literal
- I also updated README.md file about dependency version
- I also changed .gitignore because it wasn't properly ignoring zig-cache files etc.