### PR TITLE
Datetime dependency with DST

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.3.0",
     .dependencies = .{
         .datetime = .{
-            .url = "git+https://github.com/frmdstryr/zig-datetime?ref=master#52d4fbe43a758589b74411ffec8ebcb1f12e2d13",
-            .hash = "datetime-0.8.0-cJNXzNiMAQBz4RV6Gz7qUNeE-xLDNLs_jNU5_zIZ48as",
+            .url = "git+https://github.com/frmdstryr/zig-datetime?ref=master#b8dcd4948ac1dc29694a4d79794921121426981b",
+            .hash = "datetime-0.8.0-cJNXzPXXAQBatvf9tYfTS2FMKMKNGM7zJnxmetb6AWJy",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
1 of my PRs got merged to https://github.com/frmdstryr/zig-datetime that implements DST to the library: https://github.com/frmdstryr/zig-datetime/pull/40

I belive it's good to have depedency updated to there to prevent depedency conflict between your library and local dependency versions that needs DST.